### PR TITLE
implement #49

### DIFF
--- a/src/main/java/kst4contest/view/Kst4ContestApplication.java
+++ b/src/main/java/kst4contest/view/Kst4ContestApplication.java
@@ -5970,9 +5970,19 @@ public class Kst4ContestApplication extends Application implements StatusUpdateL
 			txt_myQTF.getStyleClass().add("text-input");
 			txt_myQTF.getStyleClass().add("text-input-MYQRG1");
 
-            txt_myQTF.textProperty().bind(Bindings.createStringBinding(
-                    () -> Double.toString(chatcontroller.getChatPreferences().getActualQTF().get()),
-                    chatcontroller.getChatPreferences().getActualQTF()));
+			// Rotator sync on/off determines whether this field is bound (read-only, driven
+			// by PSTRotator) or free for manual entry, mirroring the MYQRG sync behaviour above.
+			if (chatcontroller.getChatPreferences().isStn_pstRotatorEnabled()) {
+				txt_myQTF.textProperty().bind(Bindings.createStringBinding(
+						() -> Double.toString(chatcontroller.getChatPreferences().getActualQTF().get()),
+						chatcontroller.getChatPreferences().getActualQTF()));
+				txt_myQTF.setTooltip(new Tooltip("This is your current QTF, read out at PSTRotator"));
+				txt_myQTF.setFocusTraversable(false);
+			} else {
+				txt_myQTF.setText(Double.toString(chatcontroller.getChatPreferences().getActualQTF().get()));
+				txt_myQTF.setTooltip(new Tooltip("Enter your antenna heading (QTF) by hand - no rotator sync active"));
+				txt_myQTF.setFocusTraversable(true);
+			}
 
 			txt_myQTF.focusedProperty().addListener(new ChangeListener<Boolean>() {
 				@Override
@@ -5982,13 +5992,16 @@ public class Kst4ContestApplication extends Application implements StatusUpdateL
 //			            System.out.println("Textfield on focus");
 						// Do nothing until field loses focus, user will enter his frequency
 					} else {
+						if (txt_myQTF.textProperty().isBound()) {
+							return; // rotator sync active, field is driven by PSTRotator
+						}
 						try {
 						System.out.println(
 								"[Main.java, Info]: Set the MYQTF property by hand to: " + txt_myQTF.getText());
-						chatcontroller.getChatPreferences().getActualQTF().set(Integer.parseInt(txt_myQTF.getText()));}
+						chatcontroller.getChatPreferences().getActualQTF().set(Double.parseDouble(txt_myQTF.getText()));}
 						catch (Exception exception) {
 							System.out.println("bullshit entered in myqtf");
-							txt_myQTF.setText("0");
+							txt_myQTF.setText("0.0");
 						}
 					}
 				}
@@ -5997,8 +6010,6 @@ public class Kst4ContestApplication extends Application implements StatusUpdateL
 			txt_myQTF.setPrefSize(40, 0);
 //			txt_ownqrg.setMinSize(40, 0);
 			txt_myQTF.setAlignment(Pos.BASELINE_RIGHT);
-			txt_myQTF.setTooltip(new Tooltip("This is your current QTF, read out at PSTRotator"));
-			txt_myQTF.setFocusTraversable(false);
 
 			SplitPane mainWindowLeftSplitPane = new SplitPane();
 			mainWindowLeftSplitPane.setOrientation(Orientation.HORIZONTAL);
@@ -8637,9 +8648,21 @@ public class Kst4ContestApplication extends Application implements StatusUpdateL
 		chkBx_station_pstRotatorEnabled.setTooltip(new Tooltip(
 				"If disabled: no PSTRotator connection is started and antenna direction is ignored in priority scoring."
 		));
-		chkBx_station_pstRotatorEnabled.selectedProperty().addListener((obs, oldV, newV) ->
-				chatcontroller.getChatPreferences().setStn_pstRotatorEnabled(newV)
-		);
+		chkBx_station_pstRotatorEnabled.selectedProperty().addListener((obs, oldV, newV) -> {
+			chatcontroller.getChatPreferences().setStn_pstRotatorEnabled(newV);
+			if (newV) {
+				txt_myQTF.textProperty().bind(Bindings.createStringBinding(
+						() -> Double.toString(chatcontroller.getChatPreferences().getActualQTF().get()),
+						chatcontroller.getChatPreferences().getActualQTF()));
+				txt_myQTF.setTooltip(new Tooltip("This is your current QTF, read out at PSTRotator"));
+				txt_myQTF.setFocusTraversable(false);
+			} else {
+				txt_myQTF.textProperty().unbind();
+				txt_myQTF.setText(Double.toString(chatcontroller.getChatPreferences().getActualQTF().get()));
+				txt_myQTF.setTooltip(new Tooltip("Enter your antenna heading (QTF) by hand - no rotator sync active"));
+				txt_myQTF.setFocusTraversable(true);
+			}
+		});
 
 
 		grdPnlStation.add(lblCallSign, 0, 0);


### PR DESCRIPTION
This pull request enhances the handling of the MYQTF (antenna heading) input field in the `Kst4ContestApplication` to better support both manual entry and synchronization with PSTRotator. The updates ensure the UI and field behavior accurately reflect whether rotator sync is enabled, improving usability and preventing user errors.

**Improvements to MYQTF field behavior:**

* The MYQTF input field (`txt_myQTF`) now dynamically switches between read-only (bound to PSTRotator) and manual entry modes based on the rotator sync setting. Tooltips and focus behavior are updated accordingly to guide the user. [[1]](diffhunk://#diff-d603b99428999cea8d3c4fe6a8717eeeacb0ebe4fbf2e2369a03f5a0b14d2b88R5973-R5985) [[2]](diffhunk://#diff-d603b99428999cea8d3c4fe6a8717eeeacb0ebe4fbf2e2369a03f5a0b14d2b88L8640-R8665)
* When rotator sync is enabled or disabled via the corresponding checkbox, the field's binding, tooltip, and focus traversability are updated in real time to match the current mode.

**Input validation and error handling:**

* When entering a value manually, the field now correctly parses the input as a `double` instead of an `integer`, and resets to `"0.0"` on invalid input. If the field is bound (rotator sync active), user edits are ignored to prevent errors.

**Code cleanup:**

* Removed redundant tooltip and focus settings that are now handled dynamically based on the rotator sync state.