### PR TITLE
on4kst: add jdk.net to every packaging module list and stop connection setup from failing silently

### DIFF
--- a/.github/workflows/nightly-artifacts.yml
+++ b/.github/workflows/nightly-artifacts.yml
@@ -71,7 +71,7 @@ jobs:
             --main-jar app.jar `
             --main-class kst4contest.view.Kst4ContestApplication `
             --module-path target/dist-libs `
-            --add-modules javafx.controls,javafx.graphics,javafx.fxml,javafx.web,javafx.media,java.sql,java.net.http,jdk.crypto.ec `
+            --add-modules javafx.controls,javafx.graphics,javafx.fxml,javafx.web,javafx.media,java.sql,java.net.http,jdk.crypto.ec,jdk.net `
             --dest dist
 
       - name: Create Windows ZIP
@@ -128,7 +128,7 @@ jobs:
             --main-jar app.jar \
             --main-class kst4contest.view.Kst4ContestApplication \
             --module-path target/dist-libs \
-            --add-modules javafx.controls,javafx.graphics,javafx.fxml,javafx.web,javafx.media,java.sql,java.net.http,jdk.crypto.ec \
+            --add-modules javafx.controls,javafx.graphics,javafx.fxml,javafx.web,javafx.media,java.sql,java.net.http,jdk.crypto.ec,jdk.net \
             --dest dist
 
       - name: Create AppDir metadata
@@ -214,7 +214,7 @@ jobs:
             --main-jar app.jar \
             --main-class kst4contest.view.Kst4ContestApplication \
             --module-path target/dist-libs \
-            --add-modules javafx.controls,javafx.graphics,javafx.fxml,javafx.web,javafx.media,java.sql,java.net.http,jdk.crypto.ec \
+            --add-modules javafx.controls,javafx.graphics,javafx.fxml,javafx.web,javafx.media,java.sql,java.net.http,jdk.crypto.ec,jdk.net \
             --linux-package-deps "libgstreamer1.0-0,libgstreamer-plugins-base1.0-0,gstreamer1.0-plugins-good" \
             --dest dist
           DEB="$(ls dist/*.deb | head -n 1)"
@@ -274,7 +274,7 @@ jobs:
             --main-jar app.jar \
             --main-class kst4contest.view.Kst4ContestApplication \
             --module-path target/dist-libs \
-            --add-modules javafx.controls,javafx.graphics,javafx.fxml,javafx.web,javafx.media,java.sql,java.net.http,jdk.crypto.ec \
+            --add-modules javafx.controls,javafx.graphics,javafx.fxml,javafx.web,javafx.media,java.sql,java.net.http,jdk.crypto.ec,jdk.net \
             --linux-package-deps "gstreamer1,gstreamer1-plugins-base,gstreamer1-plugins-good" \
             --dest dist
           RPM="$(ls dist/*.rpm | head -n 1)"
@@ -336,7 +336,7 @@ jobs:
             --main-jar app.jar \
             --main-class kst4contest.view.Kst4ContestApplication \
             --module-path target/dist-libs \
-            --add-modules javafx.controls,javafx.graphics,javafx.fxml,javafx.web,javafx.media,java.sql,java.net.http,jdk.crypto.ec \
+            --add-modules javafx.controls,javafx.graphics,javafx.fxml,javafx.web,javafx.media,java.sql,java.net.http,jdk.crypto.ec,jdk.net \
             --dest dist
 
       - name: Build Arch Linux package artifact
@@ -455,7 +455,7 @@ jobs:
             --main-jar app.jar \
             --main-class kst4contest.view.Kst4ContestApplication \
             --module-path target/dist-libs \
-            --add-modules javafx.controls,javafx.graphics,javafx.fxml,javafx.web,javafx.media,java.sql,java.net.http,jdk.crypto.ec \
+            --add-modules javafx.controls,javafx.graphics,javafx.fxml,javafx.web,javafx.media,java.sql,java.net.http,jdk.crypto.ec,jdk.net \
             --dest target/flatpak-src
 
       - name: Create Flatpak manifest
@@ -643,7 +643,7 @@ jobs:
             --main-jar app.jar \
             --main-class kst4contest.view.Kst4ContestApplication \
             --module-path target/dist-libs \
-            --add-modules javafx.controls,javafx.graphics,javafx.fxml,javafx.web,javafx.media,java.sql,java.net.http,jdk.crypto.ec \
+            --add-modules javafx.controls,javafx.graphics,javafx.fxml,javafx.web,javafx.media,java.sql,java.net.http,jdk.crypto.ec,jdk.net \
             --dest dist
 
         env:

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -56,7 +56,7 @@ jobs:
             --main-jar app.jar `
             --main-class kst4contest.view.Kst4ContestApplication `
             --module-path target/dist-libs `
-            --add-modules javafx.controls,javafx.graphics,javafx.fxml,javafx.web,javafx.media,java.sql,java.net.http,jdk.crypto.ec `
+            --add-modules javafx.controls,javafx.graphics,javafx.fxml,javafx.web,javafx.media,java.sql,java.net.http,jdk.crypto.ec,jdk.net `
             --dest dist
 
       - name: Create Windows ZIP
@@ -106,7 +106,7 @@ jobs:
             --main-jar app.jar \
             --main-class kst4contest.view.Kst4ContestApplication \
             --module-path target/dist-libs \
-            --add-modules javafx.controls,javafx.graphics,javafx.fxml,javafx.web,javafx.media,java.sql,java.net.http,jdk.crypto.ec \
+            --add-modules javafx.controls,javafx.graphics,javafx.fxml,javafx.web,javafx.media,java.sql,java.net.http,jdk.crypto.ec,jdk.net \
             --dest dist
 
       - name: Create AppDir metadata
@@ -185,7 +185,7 @@ jobs:
             --main-jar app.jar \
             --main-class kst4contest.view.Kst4ContestApplication \
             --module-path target/dist-libs \
-            --add-modules javafx.controls,javafx.graphics,javafx.fxml,javafx.web,javafx.media,java.sql,java.net.http,jdk.crypto.ec \
+            --add-modules javafx.controls,javafx.graphics,javafx.fxml,javafx.web,javafx.media,java.sql,java.net.http,jdk.crypto.ec,jdk.net \
             --linux-package-deps "libgstreamer1.0-0,libgstreamer-plugins-base1.0-0,gstreamer1.0-plugins-good" \
             --dest dist
           DEB="$(ls dist/*.deb | head -n 1)"
@@ -238,7 +238,7 @@ jobs:
             --main-jar app.jar \
             --main-class kst4contest.view.Kst4ContestApplication \
             --module-path target/dist-libs \
-            --add-modules javafx.controls,javafx.graphics,javafx.fxml,javafx.web,javafx.media,java.sql,java.net.http,jdk.crypto.ec \
+            --add-modules javafx.controls,javafx.graphics,javafx.fxml,javafx.web,javafx.media,java.sql,java.net.http,jdk.crypto.ec,jdk.net \
             --linux-package-deps "gstreamer1,gstreamer1-plugins-base,gstreamer1-plugins-good" \
             --dest dist
           RPM="$(ls dist/*.rpm | head -n 1)"
@@ -291,7 +291,7 @@ jobs:
             --main-jar app.jar \
             --main-class kst4contest.view.Kst4ContestApplication \
             --module-path target/dist-libs \
-            --add-modules javafx.controls,javafx.graphics,javafx.fxml,javafx.web,javafx.media,java.sql,java.net.http,jdk.crypto.ec \
+            --add-modules javafx.controls,javafx.graphics,javafx.fxml,javafx.web,javafx.media,java.sql,java.net.http,jdk.crypto.ec,jdk.net \
             --dest dist
 
       - name: Build Arch Linux package artifact
@@ -401,7 +401,7 @@ jobs:
             --main-jar app.jar \
             --main-class kst4contest.view.Kst4ContestApplication \
             --module-path target/dist-libs \
-            --add-modules javafx.controls,javafx.graphics,javafx.fxml,javafx.web,javafx.media,java.sql,java.net.http,jdk.crypto.ec \
+            --add-modules javafx.controls,javafx.graphics,javafx.fxml,javafx.web,javafx.media,java.sql,java.net.http,jdk.crypto.ec,jdk.net \
             --dest target/flatpak-src
 
       - name: Create Flatpak manifest
@@ -531,7 +531,7 @@ jobs:
             --main-jar app.jar \
             --main-class kst4contest.view.Kst4ContestApplication \
             --module-path target/dist-libs \
-            --add-modules javafx.controls,javafx.graphics,javafx.fxml,javafx.web,javafx.media,java.sql,java.net.http,jdk.crypto.ec \
+            --add-modules javafx.controls,javafx.graphics,javafx.fxml,javafx.web,javafx.media,java.sql,java.net.http,jdk.crypto.ec,jdk.net \
             --dest dist
 
         env:

--- a/packaging/aur/kst4contest-git/PKGBUILD
+++ b/packaging/aur/kst4contest-git/PKGBUILD
@@ -40,7 +40,7 @@ build() {
         --main-jar app.jar \
         --main-class kst4contest.view.Kst4ContestApplication \
         --module-path target/dist-libs \
-        --add-modules javafx.controls,javafx.graphics,javafx.fxml,javafx.web,javafx.media,java.sql,java.net.http,jdk.crypto.ec \
+        --add-modules javafx.controls,javafx.graphics,javafx.fxml,javafx.web,javafx.media,java.sql,java.net.http,jdk.crypto.ec,jdk.net \
         --dest dist
 }
 

--- a/packaging/aur/kst4contest/PKGBUILD
+++ b/packaging/aur/kst4contest/PKGBUILD
@@ -33,7 +33,7 @@ build() {
         --main-jar app.jar \
         --main-class kst4contest.view.Kst4ContestApplication \
         --module-path target/dist-libs \
-        --add-modules javafx.controls,javafx.graphics,javafx.fxml,javafx.web,javafx.media,java.sql,java.net.http,jdk.crypto.ec \
+        --add-modules javafx.controls,javafx.graphics,javafx.fxml,javafx.web,javafx.media,java.sql,java.net.http,jdk.crypto.ec,jdk.net \
         --dest dist
 }
 

--- a/src/main/java/kst4contest/controller/On4KstConnectionManager.java
+++ b/src/main/java/kst4contest/controller/On4KstConnectionManager.java
@@ -285,7 +285,10 @@ final class On4KstConnectionManager {
             scheduler.schedule(
                     () -> sendLogin(token), LOGIN_FALLBACK_MILLIS,
                     TimeUnit.MILLISECONDS);
-        } catch (Exception exception) {
+        } catch (Throwable exception) {
+            // Errors must be caught as well: an Error escaping here would be
+            // swallowed by the scheduler and leave the state machine stuck in
+            // CONNECTING without any reconnect attempt or user visible failure.
             try {
                 socket.close();
             } catch (IOException ignored) {
@@ -699,7 +702,9 @@ final class On4KstConnectionManager {
             socket.setOption(ExtendedSocketOptions.TCP_KEEPIDLE, 45);
             socket.setOption(ExtendedSocketOptions.TCP_KEEPINTERVAL, 15);
             socket.setOption(ExtendedSocketOptions.TCP_KEEPCOUNT, 3);
-        } catch (UnsupportedOperationException | IOException exception) {
+        } catch (UnsupportedOperationException | IOException | LinkageError exception) {
+            // LinkageError covers runtime images built without the jdk.net module;
+            // the connection stays usable, only kernel side keepalive is missing.
             LOGGER.log(Level.INFO,
                     "Platform does not support configurable TCP keepalive; "
                             + "application heartbeat remains active", exception);


### PR DESCRIPTION
## Problem

Connecting to ON4KST works in the development environment and in `beta-v1.42.0-rc03`, but fails in every packaged build produced after f8c04e7 (#75). The connection stays stuck at CONNECTING with no reconnect attempt and no error message.

## Root cause

f8c04e7 introduced `On4KstConnectionManager`, which configures kernel side TCP keepalives:

```java
import jdk.net.ExtendedSocketOptions;
socket.setOption(ExtendedSocketOptions.TCP_KEEPIDLE, 45);
```

The new module dependency was added in two places — `module-info.java` (`requires jdk.net`) and `pom.xml` (`<addmodule>jdk.net</addmodule>`) — but the CI and AUR builds do not use the jpackage Maven plugin. They call `jpackage` directly with a hardcoded module list that still lacked `jdk.net`:

```
--add-modules javafx.controls,javafx.graphics,javafx.fxml,javafx.web,javafx.media,java.sql,java.net.http,jdk.crypto.ec
```

`jdk.net` is not pulled in transitively, verified with `jlink` + `--list-modules`:

```
java.base java.logging java.net.http java.sql java.transaction.xa java.xml jdk.crypto.ec
```

So the shipped runtime image simply does not contain `jdk.net.ExtendedSocketOptions`. Development runs against the full JDK, which is why it never showed up there, and RC03 did not contain the code at all.

## Why the failure was silent

Reproduced with exactly the CI module list:

```
Exception in thread "main" java.lang.NoClassDefFoundError: jdk/net/ExtendedSocketOptions
```

Three things combined:

1. `configureSocket` caught only `UnsupportedOperationException | IOException`. `NoClassDefFoundError` is an `Error`, so it did not match.
2. The surrounding `catch (Exception exception)` in `openConnection` did not match either, so neither `socket.close()` nor `handleOpenFailure()` ran — no reconnect, no status update.
3. `openConnection` runs via `scheduler.execute(...)` on a `ScheduledExecutorService`, where an escaping throwable is stored in the task future and never logged.

The TCP connect itself still succeeded; the task then died silently one line later.

## Scope

The stale module list appeared in **16 places**, so tagged releases were affected as well, not just nightlies:

| File | Occurrences |
|---|---|
| `.github/workflows/nightly-artifacts.yml` | 7 |
| `.github/workflows/tagged-release.yml` | 7 |
| `packaging/aur/kst4contest/PKGBUILD` | 1 |
| `packaging/aur/kst4contest-git/PKGBUILD` | 1 |

## Changes

1. Add `jdk.net` to all 16 `--add-modules` lists. This fixes the bug.
2. Catch `LinkageError` in `configureSocket`, so a runtime image without `jdk.net` degrades to "no kernel keepalive, application heartbeat still active" instead of breaking the connection.
3. Catch `Throwable` in `openConnection`, so an `Error` can no longer be swallowed by the scheduler. `handleOpenFailure` already accepted `Throwable`.

## Verification

- `./mvnw compile` clean, `./mvnw test` → 26 tests, 0 failures, BUILD SUCCESS
- Runtime image built with the **new** module list: `jdk.net` present, `TCP_KEEPIDLE` applied successfully
- Counter-check with the **old** module list plus the new catch: `NoClassDefFoundError` is caught and connection setup continues, where it previously died silently

## Follow-up (not in this PR)

The underlying weakness is duplication: 16 copies of the module list plus `module-info.java` plus `pom.xml` must be kept in sync manually, and only the path CI does *not* use was maintained. Worth either replacing the direct `jpackage` calls with the Maven plugin or hoisting the module list into a single shared variable.

Unrelated side note spotted while investigating: `On4KstProtocolTest.java` and `On4KstSocketThreadTest.java` live in `src/main/java/` rather than the test sources, so Surefire never runs them, and `module-info.java` has to `requires org.junit.jupiter.api` and `org.mockito` at runtime because of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
